### PR TITLE
Per-node mechanism registry: mix MLP with TabICL tree-SCM mechanisms

### DIFF
--- a/plurel/config.py
+++ b/plurel/config.py
@@ -73,7 +73,7 @@ class RandomFunctionActivation:
     Params (n components, amplitudes, freqs, phases) are sampled once at
     construction so the activation is a deterministic function of its input.
     Each MLP layer that picks this activation gets a fresh instance — see
-    `MLP.__init__` — which keeps SCMs deterministic functions of their
+    `MLPMechanism.__init__` — which keeps SCMs deterministic functions of their
     inputs and decouples per-row outputs from how rows are batched.
     """
 
@@ -202,6 +202,12 @@ class SCMParams:
     mlp_emb_dim: int = 32
     mlp_num_layers_choices: Choices = Choices(kind="range", value=[2, 4])
     mlp_weight_density_choices: Choices = Choices(kind="range", value=[0.3, 1.0])
+    mechanism_type_choices: Choices = Choices(kind="set", value=["mlp", "tree"])
+    tree_model_choices: Choices = Choices(
+        kind="set", value=["decision_tree", "extra_trees", "random_forest"]
+    )
+    tree_depth_lambda: float = 0.5
+    tree_n_estimators_lambda: float = 0.5
     source_gen_type_choices: Choices = Choices(
         kind="set", value=["ts", "uniform", "gaussian", "beta", "mixed"]
     )

--- a/plurel/scm.py
+++ b/plurel/scm.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 from plurel.bipartite import sample_bipartite_assignments
 from plurel.config import DAGParams, SCMParams
 from plurel.dag import DAG_REGISTRY
-from plurel.transforms import MLP, CategoricalDecoder, CategoricalEncoder
+from plurel.transforms import CategoricalDecoder, CategoricalEncoder, make_mechanism
 from plurel.ts import (
     BetaSourceGenerator,
     CategoricalTSDataGenerator,
@@ -167,7 +167,7 @@ class PropagationStrategy:
         self.mlp_emb_dim = scm_params.mlp_emb_dim
 
     def _get_numerical_encoder(self):
-        return MLP(
+        return make_mechanism(
             scm_params=self.scm_params,
             in_dim=self.scm_params.mlp_in_dim,
             hid_dim=self.mlp_emb_dim,
@@ -175,7 +175,7 @@ class PropagationStrategy:
         )
 
     def _get_numerical_decoder(self):
-        return MLP(
+        return make_mechanism(
             scm_params=self.scm_params,
             in_dim=self.mlp_emb_dim,
             hid_dim=self.mlp_emb_dim,

--- a/plurel/transforms.py
+++ b/plurel/transforms.py
@@ -1,12 +1,62 @@
+import abc
 import math
 
 import numpy as np
 import torch
+from sklearn.ensemble import ExtraTreesRegressor, RandomForestRegressor
+from sklearn.tree import DecisionTreeRegressor
 
 from plurel.config import RandomFunctionActivation, SCMParams
 
 
-class MLP:
+def _build_tree_regressor(tree_model: str, max_depth: int, n_estimators: int):
+    if tree_model == "decision_tree":
+        return DecisionTreeRegressor(max_depth=max_depth, splitter="random")
+    if tree_model == "extra_trees":
+        return ExtraTreesRegressor(n_estimators=n_estimators, max_depth=max_depth, n_jobs=1)
+    if tree_model == "random_forest":
+        return RandomForestRegressor(n_estimators=n_estimators, max_depth=max_depth, n_jobs=1)
+    if tree_model == "xgboost":
+        from xgboost import XGBRegressor
+
+        return XGBRegressor(
+            n_estimators=n_estimators,
+            max_depth=max_depth,
+            tree_method="hist",
+            multi_strategy="multi_output_tree",
+            n_jobs=1,
+        )
+    raise ValueError(f"Invalid tree model: {tree_model}")
+
+
+class Mechanism(abc.ABC):
+    """A frozen random function mapping node/edge inputs to outputs.
+
+    Every mechanism is constructed with the same signature
+    ``(scm_params, in_dim, hid_dim, out_dim)`` and called as ``m(x)`` where
+    ``x`` has shape ``(..., in_dim)`` and the result has shape
+    ``(..., out_dim)``. A mechanism's parameters are fixed for its lifetime, so
+    it behaves as a deterministic function reused across propagation chunks.
+    ``MLPMechanism`` is additionally invariant to how rows are batched;
+    ``TreeMechanism`` fits on its first call, so it is batch-invariant only when
+    every row is seen in that first call. Register concrete subclasses in
+    ``MECHANISM_REGISTRY``.
+    """
+
+    @abc.abstractmethod
+    def __init__(
+        self,
+        scm_params: SCMParams,
+        in_dim: int,
+        hid_dim: int,
+        out_dim: int,
+    ): ...
+
+    @abc.abstractmethod
+    def __call__(self, x: torch.Tensor) -> torch.Tensor: ...
+
+
+class MLPMechanism(Mechanism):
     def __init__(
         self,
         scm_params: SCMParams,
@@ -41,6 +91,53 @@ class MLP:
         return x @ self.weights[-1]
 
 
+class TreeMechanism(Mechanism):
+    """Tree-based mechanism ported from TabICL's TreeLayer.
+
+    A tree regressor is fit against random Gaussian targets and its predictions
+    become the output — a piecewise-constant map whose partition is calibrated
+    to the input distribution. The fit happens once on the first call and is
+    cached, so the mechanism stays a frozen function reused across chunks.
+    """
+
+    def __init__(
+        self,
+        scm_params: SCMParams,
+        in_dim: int,
+        hid_dim: int,
+        out_dim: int,
+    ):
+        self.out_dim = out_dim
+        tree_model = scm_params.tree_model_choices.sample_uniform()
+        max_depth = 2 + int(np.random.exponential(1.0 / scm_params.tree_depth_lambda))
+        n_estimators = 1 + int(np.random.exponential(1.0 / scm_params.tree_n_estimators_lambda))
+        self.model = _build_tree_regressor(tree_model, max_depth, n_estimators)
+        self._fitted = False
+
+    def __call__(self, x):
+        orig_shape = x.shape[:-1]
+        X = x.reshape(-1, x.shape[-1]).nan_to_num(0.0).detach().cpu().numpy()
+        if not self._fitted:
+            y_fake = np.random.randn(X.shape[0], self.out_dim)
+            self.model.fit(X, y_fake.ravel() if self.out_dim == 1 else y_fake)
+            self._fitted = True
+        y = np.asarray(self.model.predict(X), dtype=np.float32).reshape(-1, self.out_dim)
+        return torch.from_numpy(y).reshape(*orig_shape, self.out_dim)
+
+
+MECHANISM_REGISTRY: dict[str, type[Mechanism]] = {
+    "mlp": MLPMechanism,
+    "tree": TreeMechanism,
+}
+
+
+def make_mechanism(scm_params: SCMParams, in_dim: int, hid_dim: int, out_dim: int):
+    name = scm_params.mechanism_type_choices.sample_uniform()
+    return MECHANISM_REGISTRY[name](
+        scm_params=scm_params, in_dim=in_dim, hid_dim=hid_dim, out_dim=out_dim
+    )
+
+
 class CategoricalEncoder:
     def __init__(
         self,
@@ -53,7 +150,7 @@ class CategoricalEncoder:
         )
         init_fn = scm_params.initialization_choices.sample_uniform()
         init_fn(self.E.weight)
-        self.mlp = MLP(
+        self.mechanism = make_mechanism(
             scm_params=scm_params,
             in_dim=embedding_dim,
             hid_dim=embedding_dim,
@@ -61,7 +158,7 @@ class CategoricalEncoder:
         )
 
     def __call__(self, x: torch.LongTensor):
-        return self.mlp(self.E(x))
+        return self.mechanism(self.E(x))
 
 
 class CategoricalDecoder:
@@ -76,7 +173,7 @@ class CategoricalDecoder:
         )
         init_fn = scm_params.initialization_choices.sample_uniform()
         init_fn(self.E.weight)
-        self.mlp = MLP(
+        self.mechanism = make_mechanism(
             scm_params=scm_params,
             in_dim=embedding_dim,
             hid_dim=embedding_dim,
@@ -84,7 +181,7 @@ class CategoricalDecoder:
         )
 
     def __call__(self, x: torch.Tensor):
-        x = self.mlp(x)
+        x = self.mechanism(x)
         if x.dim() == 1:
             sims = self.E.weight @ x
         else:

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1,0 +1,55 @@
+import pytest
+import torch
+
+from plurel.config import Choices, SCMParams
+from plurel.transforms import MLPMechanism, TreeMechanism, make_mechanism
+from plurel.utils import set_random_seed
+
+# (in_dim, out_dim) for the three sites make_mechanism is used at:
+# numerical encoder (1 -> emb), numerical decoder (emb -> 1), categorical (emb -> emb).
+SHAPE_SITES = [(1, 32), (32, 1), (32, 32)]
+TREE_MODELS = SCMParams().tree_model_choices.value
+
+
+def _params(**overrides):
+    return SCMParams(**overrides)
+
+
+def test_make_mechanism_dispatch():
+    mlp = make_mechanism(
+        _params(mechanism_type_choices=Choices(kind="set", value=["mlp"])), 32, 32, 1
+    )
+    tree = make_mechanism(
+        _params(mechanism_type_choices=Choices(kind="set", value=["tree"])), 32, 32, 1
+    )
+    assert isinstance(mlp, MLPMechanism)
+    assert isinstance(tree, TreeMechanism)
+
+
+@pytest.mark.parametrize("tree_model", TREE_MODELS)
+def test_tree_mechanism_shape_and_finite(tree_model):
+    p = _params(tree_model_choices=Choices(kind="set", value=[tree_model]))
+    for in_dim, out_dim in SHAPE_SITES:
+        y = TreeMechanism(scm_params=p, in_dim=in_dim, hid_dim=32, out_dim=out_dim)(
+            torch.randn(64, in_dim)
+        )
+        assert y.shape == (64, out_dim)
+        assert torch.isfinite(y).all()
+
+
+def test_tree_mechanism_fits_once_and_reuses():
+    m = TreeMechanism(scm_params=_params(), in_dim=8, hid_dim=32, out_dim=4)
+    m(torch.randn(50, 8))
+    fitted_model = m.model
+    y = m(torch.randn(23, 8))
+    assert m.model is fitted_model  # a later, differently-sized call must not refit
+    assert y.shape == (23, 4)
+
+
+def test_tree_mechanism_reproducible_under_seed():
+    x = torch.randn(40, 16)
+    outs = []
+    for _ in range(2):
+        set_random_seed(123)
+        outs.append(TreeMechanism(scm_params=_params(), in_dim=16, hid_dim=32, out_dim=4)(x))
+    assert torch.equal(outs[0], outs[1])


### PR DESCRIPTION
## Motivation

Stage 1 of making the single-table prior strictly more diverse than the TabICL prior (`soda-inria/tabicl`). plurel's per-node functional form was **exclusively a smooth MLP**, so it could not represent the axis-aligned threshold/step relationships that TabICL gets from its tree-based SCMs — and that real tabular data is full of.

## Change

- **`plurel/transforms.py`** — add an abstract `Mechanism` base (documents the shared `(scm_params, in_dim, hid_dim, out_dim)` constructor and `(..., in_dim) -> (..., out_dim)` call contract), with `MLPMechanism` (the existing MLP, renamed) and a new `TreeMechanism`. A `MECHANISM_REGISTRY` + `make_mechanism` factory sample the family per site.
- **`TreeMechanism` is ported from TabICL's `TreeLayer`**: fit a scikit-learn tree regressor (`decision_tree`/`extra_trees`/`random_forest`; `xgboost` via optional import) on **random Gaussian targets**, then predict — a piecewise-constant map whose partition is calibrated to the input distribution. Depth/estimators use TabICL's sampling: `max_depth = 2 + Exp(1/λ)`, `n_estimators = 1 + Exp(1/λ)`, `λ = 0.5`.
- **`plurel/scm.py`** — route the numerical encoder/decoder and the categorical inner net through `make_mechanism`, so **every edge-encoder and node-decoder independently samples** its mechanism family.
- **`plurel/config.py`** — `mechanism_type_choices` (`mlp`/`tree`), `tree_model_choices`, `tree_depth_lambda`, `tree_n_estimators_lambda`.

## Improvements over TabICL's implementation

1. **Per-node/per-edge mixing** — TabICL picks one family per dataset (0.7 MLP / 0.3 tree); here a single dataset contains both smooth and piecewise-constant relations (combinatorially larger space).
2. **Native multi-output trees** — TabICL wraps sklearn trees in `MultiOutputRegressor` (one independent tree per output dim → 32 fits at `emb_dim=32`). sklearn trees are natively multi-output, so a single tree with a shared partition serves all outputs (matching XGBoost's `multi_output_tree`). **~8× faster** generation.
3. **Fit-once caching** — TabICL's `forward` refits on every call; here the tree is fit once and cached, so a mechanism is a genuine frozen function reused across chunks.
4. **Sampled tree family** — TabICL's shipped config fixes `xgboost`; here the family is sampled per mechanism.

## Notes / caveats

- **scikit-learn** is already a dependency; **xgboost** is not installed, so it's excluded from the default `tree_model_choices` but supported via optional import if present.
- **Batch-invariance:** MLP mechanisms are exactly batch-invariant; a fitted tree is calibrated on its first chunk, so it is exactly batch-invariant only when a table fits within one `propagate_batch_size` (always true in the `num_tables=1` target regime at <= 1000 rows << 4096).

## Verification

- Full suite: **930 passed in ~27s** (0 tree-related warnings).
- Generation timing: single-table tree-only ~0.2s; default large multi-table ~4s.
- Shapes/finiteness checked for all tree families at the `1->32`, `32->1`, `32->32` sites; ABC enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)