### PR TITLE
Log-scaled node-noise magnitude + Gaussian noise family (from TabICL)

### DIFF
--- a/plurel/config.py
+++ b/plurel/config.py
@@ -50,6 +50,12 @@ class Choices:
         elif self.kind == "set":
             return np.random.choice(self.value, size=size, replace=replace)
 
+    def sample_log_uniform(self, size: int | None = None):
+        if self.kind == "range" and type(self.value[0]) == float:
+            low, high = math.log(self.value[0]), math.log(self.value[1])
+            return np.exp(np.random.uniform(low=low, high=high, size=size))
+        raise ValueError("log-uniform sampling requires a float 'range' with positive bounds")
+
     def sample_pl(self, exponent: float = 1, size: int | None = None, replace: bool = False):
         if self.kind == "range":
             if type(self.value[0]) == int:
@@ -174,6 +180,9 @@ class SCMParams:
     )
     node_noise_alpha_choices: Choices = Choices(kind="range", value=[0.5, 5.0])
     node_noise_beta_choices: Choices = Choices(kind="range", value=[0.5, 5.0])
+    node_noise_type_choices: Choices = Choices(kind="set", value=["beta", "gaussian"])
+    node_noise_std_choices: Choices = Choices(kind="range", value=[1e-4, 0.3])
+    pre_sample_noise_std_choices: Choices = Choices(kind="set", value=[True, False])
 
     bi_hsbm_levels_choices: Choices = Choices(kind="range", value=[1, 5])
     bi_hsbm_clusters_per_level_choices: Choices = Choices(kind="range", value=[1, 3])

--- a/plurel/scm.py
+++ b/plurel/scm.py
@@ -321,6 +321,49 @@ AGGREGATION_REGISTRY: dict[str, callable] = {
 }
 
 
+class NoiseGenerator:
+    """Additive per-node noise, sampled at shape (num_rows, emb_dim)."""
+
+    def sample(self, num_rows: int, emb_dim: int) -> torch.Tensor:
+        raise NotImplementedError
+
+
+class GaussianNoiseGenerator(NoiseGenerator):
+    def __init__(self, scm_params: SCMParams, std: float | torch.Tensor):
+        self.std = std
+
+    def sample(self, num_rows, emb_dim):
+        return torch.randn(num_rows, emb_dim) * self.std
+
+
+class BetaNoiseGenerator(NoiseGenerator):
+    def __init__(self, scm_params: SCMParams, std: float | torch.Tensor):
+        alpha = float(scm_params.node_noise_alpha_choices.sample_uniform())
+        beta = float(scm_params.node_noise_beta_choices.sample_uniform())
+        self.dist = Beta(torch.tensor([alpha]), torch.tensor([beta]))
+        self.std = std
+
+    def sample(self, num_rows, emb_dim):
+        return self.dist.sample(sample_shape=(num_rows, emb_dim)).squeeze(-1) * self.std
+
+
+NOISE_GENERATOR_REGISTRY: dict[str, type[NoiseGenerator]] = {
+    "beta": BetaNoiseGenerator,
+    "gaussian": GaussianNoiseGenerator,
+}
+
+
+def make_noise_generator(scm_params: SCMParams, emb_dim: int) -> NoiseGenerator:
+    noise_type = scm_params.node_noise_type_choices.sample_uniform()
+    base_std = float(scm_params.node_noise_std_choices.sample_log_uniform())
+    per_dim = (
+        torch.randn(1, emb_dim).abs()
+        if scm_params.pre_sample_noise_std_choices.sample_uniform()
+        else 1.0
+    )
+    return NOISE_GENERATOR_REGISTRY[noise_type](scm_params=scm_params, std=base_std * per_dim)
+
+
 class SCM:
     def __init__(
         self,
@@ -421,10 +464,8 @@ class SCM:
                 )
                 self.dag.graph.nodes[node]["num_categories"] = num_categories
 
-            alpha = float(self.scm_params.node_noise_alpha_choices.sample_uniform())
-            beta = float(self.scm_params.node_noise_beta_choices.sample_uniform())
-            self.dag.graph.nodes[node]["noise_dist"] = Beta(
-                torch.tensor([alpha]), torch.tensor([beta])
+            self.dag.graph.nodes[node]["noise_generator"] = make_noise_generator(
+                scm_params=self.scm_params, emb_dim=self.strategy.mlp_emb_dim
             )
             self.dag.graph.nodes[node]["propagation_agg"] = (
                 self.scm_params.propagation_agg_choices.sample_uniform()
@@ -488,9 +529,8 @@ class SCM:
         for node in self.dag.graph.nodes:
             if node in self.source_nodes:
                 continue
-            noise_dist = self.dag.graph.nodes[node]["noise_dist"]
-            node_noise[node] = (
-                noise_dist.sample(sample_shape=(self.num_rows, emb_dim)).squeeze(-1) / emb_dim
+            node_noise[node] = self.dag.graph.nodes[node]["noise_generator"].sample(
+                self.num_rows, emb_dim
             )
 
         foreign_table_names = list(self.fkey_col_to_pkey_table.values())

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,22 @@
+import math
+
+import pytest
+
+from plurel.config import Choices
+
+
+def test_sample_log_uniform_is_log_scaled_within_bounds():
+    lo, hi = 1e-4, 0.3
+    s = Choices(kind="range", value=[lo, hi]).sample_log_uniform(size=20000)
+    assert s.min() >= lo and s.max() <= hi
+    # log-uniform puts ~half the mass below the geometric mean (a linear-uniform
+    # sampler would put only ~2% there), so this distinguishes the two.
+    geo_mean = math.sqrt(lo * hi)
+    assert 0.45 < (s < geo_mean).mean() < 0.55
+
+
+def test_sample_log_uniform_requires_positive_float_range():
+    with pytest.raises(ValueError):
+        Choices(kind="range", value=[1, 10]).sample_log_uniform()  # int range
+    with pytest.raises(ValueError):
+        Choices(kind="set", value=[0.1, 0.2]).sample_log_uniform()


### PR DESCRIPTION
## Motivation

Stage 2 of making the single-table prior more diverse than the TabICL prior. plurel's node noise was **fixed**: Beta noise scaled by a hardwired `1/emb_dim`, with no tunable magnitude and only one family. TabICL samples a **log-scaled `noise_std`** and injects **additive Gaussian** noise, optionally per-dimension.

## Change (ported from TabICL's `GaussianNoise` / `noise_std` handling)

Per **node**, sample:
- `noise_type` ∈ `{beta, gaussian}` — Gaussian is `base ~ N(0, 1)` (i.e. TabICL's `X + normal(0, std)`); Beta is plurel's existing family.
- `noise_std` — the magnitude, **log-scaled** in `[1e-4, 0.3]` (TabICL's range), replacing the fixed `1/emb_dim`.
- `pre_sample_noise_std` (bool) — TabICL's per-dimension std: `abs(normal(0, noise_std))` of shape `(1, emb_dim)`, else a scalar.

Noise is then `base * std`, keeping the existing pre-sample-per-(node,row) structure so it stays chunk-invariant.

**Files:** `plurel/config.py` (new choices + `Choices.sample_log_uniform`), `plurel/scm.py` (sample noise attrs per node; build noise by family).

## Improvements over TabICL

1. **Two families, not one** — keeps plurel's Beta (asymmetric, bounded) *and* adds TabICL's Gaussian; TabICL has only Gaussian.
2. **Per-node sampling** — noise type/magnitude/pre-sample vary per node rather than per dataset/layer.

## Tests

`test/test_config.py` — one focused test that `sample_log_uniform` is actually log-scaled (≈half the mass below the geometric mean, which a linear sampler would not produce) and stays in-bounds, plus its positive-float-range contract. The family/pre-sample branching is exercised and finiteness-checked by the existing generation tests.

## Verification

- Full suite: **936 passed** (+2 new = 938 on this branch).
- Generation across `gaussian`-only, `beta`-only, and `pre_sample` on/off produces finite, well-scaled columns (single- and multi-table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)