### PR TITLE
Add value-mode categorical boundaries (from TabICL reg2cls)

### DIFF
--- a/plurel/config.py
+++ b/plurel/config.py
@@ -223,6 +223,7 @@ class SCMParams:
     source_beta_alpha_choices: Choices = Choices(kind="range", value=[0.5, 5.0])
     source_beta_beta_choices: Choices = Choices(kind="range", value=[0.5, 5.0])
     propagation_mode_choices: Choices = Choices(kind="set", value=["type_eager", "type_lazy"])
+    cat_boundary_mode_choices: Choices = Choices(kind="set", value=["rank", "value"])
     cat_label_permute_prob_choices: Choices = Choices(kind="range", value=[0.3, 1.0])
     cat_label_reverse_prob_choices: Choices = Choices(kind="range", value=[0.2, 0.8])
 

--- a/plurel/scm.py
+++ b/plurel/scm.py
@@ -320,6 +320,11 @@ AGGREGATION_REGISTRY: dict[str, callable] = {
     "logexp": lambda s: torch.logsumexp(s, dim=0),
 }
 
+CATEGORICAL_BOUNDARY_REGISTRY: dict[str, callable] = {
+    "rank": lambda values, k: values[torch.randint(0, len(values), (k,))],
+    "value": lambda values, k: torch.randn(k),
+}
+
 
 class NoiseGenerator:
     """Additive per-node noise, sampled at shape (num_rows, emb_dim)."""
@@ -632,10 +637,9 @@ class SCM:
             col_name = self.dag.graph.nodes[node]["col_name"]
             num_categories = self.dag.graph.nodes[node]["num_categories"]
             col_values = torch.tensor(self.df[col_name].values, dtype=torch.float32)
-            # Sample random boundaries from the data itself
-            boundary_indices = torch.randint(0, len(col_values), (num_categories - 1,))
-            boundaries = col_values[boundary_indices]
-            # Count how many boundaries each value exceeds → class label in [0, num_categories-1]
+            col_values = (col_values - col_values.mean()) / col_values.std().clamp_min(1e-8)
+            mode = self.scm_params.cat_boundary_mode_choices.sample_uniform()
+            boundaries = CATEGORICAL_BOUNDARY_REGISTRY[mode](col_values, num_categories - 1)
             classes = (col_values.unsqueeze(-1) > boundaries.unsqueeze(0)).sum(dim=1)
             # randomly permute class labels to break ordinality
             permute_prob = self.scm_params.cat_label_permute_prob_choices.sample_uniform()


### PR DESCRIPTION
## Motivation

Stage 3 of making the single-table prior more diverse than the TabICL prior. In lazy propagation, plurel quantizes numerical columns into categoricals using boundaries **drawn from the data** — which is exactly TabICL's `"rank"` mode. It was missing TabICL's `"value"` mode, where boundaries come from a standard normal.

## Change (ported from TabICL's `MulticlassAssigner`)

- **`plurel/scm.py`** — add `CATEGORICAL_BOUNDARY_REGISTRY` (mirroring `AGGREGATION_REGISTRY`):
  - `"rank"` → `values[randint(0, N, (k,))]` (the existing behavior)
  - `"value"` → `torch.randn(k)`
  Each categorical column samples its mode. Columns are **standardized** before assignment so the normal-distributed `"value"` boundaries split them meaningfully; standardization is monotonic, so `"rank"` results are unchanged.
- **`plurel/config.py`** — `cat_boundary_mode_choices` (`rank`/`value`).

plurel's existing label **permute/reverse** are retained (they already mirror TabICL's permute + 50% reversal).

## Verification

- Full suite: **938 passed**.
- End-to-end lazy quantization with `rank`-only and `value`-only produces valid class labels; default mixed generation unaffected.

No new test: the change is two boundary lambdas + standardization, and the `value` path is exercised by the existing `type_lazy` generation tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)