### PR TITLE
Add block-wise dropout weight init (from TabICL mlp_scm)

### DIFF
--- a/plurel/config.py
+++ b/plurel/config.py
@@ -211,6 +211,9 @@ class SCMParams:
     mlp_emb_dim: int = 32
     mlp_num_layers_choices: Choices = Choices(kind="range", value=[2, 4])
     mlp_weight_density_choices: Choices = Choices(kind="range", value=[0.3, 1.0])
+    weight_init_choices: Choices = Choices(kind="set", value=["standard", "block_dropout"])
+    mlp_init_std_choices: Choices = Choices(kind="range", value=[0.01, 10.0])
+    scale_init_std_by_dropout_choices: Choices = Choices(kind="set", value=[True, False])
     mechanism_type_choices: Choices = Choices(kind="set", value=["mlp", "tree"])
     tree_model_choices: Choices = Choices(
         kind="set", value=["decision_tree", "extra_trees", "random_forest"]

--- a/plurel/transforms.py
+++ b/plurel/transforms.py
@@ -9,6 +9,34 @@ from sklearn.tree import DecisionTreeRegressor
 from plurel.config import RandomFunctionActivation, SCMParams
 
 
+def _standard_weight_init(W: torch.Tensor, scm_params: SCMParams) -> None:
+    init_fn = scm_params.initialization_choices.sample_uniform()
+    init_fn(W)
+    # Bernoulli sparsity mask with variance compensation; density=1.0 => identity
+    density = float(scm_params.mlp_weight_density_choices.sample_uniform())
+    mask = torch.bernoulli(torch.full_like(W, density))
+    W.data *= mask / max(density, 1e-6)
+
+
+def _block_dropout_weight_init(W: torch.Tensor, scm_params: SCMParams) -> None:
+    torch.nn.init.zeros_(W)
+    init_std = float(scm_params.mlp_init_std_choices.sample_log_uniform())
+    n_blocks = int(np.random.randint(1, math.ceil(math.sqrt(min(W.shape))) + 1))
+    block_size = [dim // n_blocks for dim in W.shape]
+    keep_prob = (n_blocks * block_size[0] * block_size[1]) / W.numel()
+    scale = scm_params.scale_init_std_by_dropout_choices.sample_uniform()
+    std = init_std / (keep_prob**0.5 if scale else 1)
+    for b in range(n_blocks):
+        block_slice = tuple(slice(bs * b, bs * (b + 1)) for bs in block_size)
+        torch.nn.init.normal_(W[block_slice], std=std)
+
+
+WEIGHT_INIT_REGISTRY: dict[str, callable] = {
+    "standard": _standard_weight_init,
+    "block_dropout": _block_dropout_weight_init,
+}
+
+
 def _build_tree_regressor(tree_model: str, max_depth: int, n_estimators: int):
     if tree_model == "decision_tree":
         return DecisionTreeRegressor(max_depth=max_depth, splitter="random")
@@ -69,12 +97,8 @@ class MLPMechanism(Mechanism):
         dims = [in_dim] + [hid_dim] * (num_layers - 1) + [out_dim]
         self.weights = [torch.empty(dims[i], dims[i + 1]) for i in range(num_layers)]
         for W in self.weights:
-            init_fn = scm_params.initialization_choices.sample_uniform()
-            init_fn(W)
-            # Bernoulli sparsity mask with variance compensation; density=1.0 => identity
-            density = float(scm_params.mlp_weight_density_choices.sample_uniform())
-            mask = torch.bernoulli(torch.full_like(W, density))
-            W.data *= mask / max(density, 1e-6)
+            init_strategy = scm_params.weight_init_choices.sample_uniform()
+            WEIGHT_INIT_REGISTRY[init_strategy](W, scm_params)
         self.act_scales = []
         for _ in range(num_layers - 1):
             act_fn = scm_params.activation_choices.sample_uniform()


### PR DESCRIPTION
## Motivation

Stage 5 (final) of making the single-table prior more diverse than the TabICL prior. plurel's MLP weights were always initialized the same way — an init function plus a Bernoulli density mask (uniformly random sparsity). TabICL also offers **block-wise dropout**, which builds *structured, modular* sparse sub-networks.

## Change (ported from TabICL's `initialize_with_block_dropout`)

- **`plurel/transforms.py`** — add `WEIGHT_INIT_REGISTRY`:
  - `"standard"` → plurel's existing init-fn + Bernoulli density mask
  - `"block_dropout"` → TabICL's block-diagonal init: `zeros_`, then fill `n_blocks` diagonal rectangular blocks with `normal_(std)`, `n_blocks ∈ [1, ceil(sqrt(min(shape)))]`, `keep_prob = n_blocks·bs₀·bs₁/numel`, with optional `std /= sqrt(keep_prob)`.
  - Sampled **per weight matrix** in `MLPMechanism`, so a single MLP can mix both — finer than TabICL's per-dataset `block_wise_dropout` choice.
- **`plurel/config.py`** — `weight_init_choices` (`standard`/`block_dropout`), `mlp_init_std_choices` (`[0.01, 10]`, TabICL's range, log-scaled via `sample_log_uniform`), `scale_init_std_by_dropout_choices`.

## Notes

- plurel had no MLP `init_std` scalar (it uses init *functions*); `mlp_init_std_choices` supplies the one block-dropout needs.
- **No test added:** finiteness/shape is exercised by the existing generation tests, and I manually verified the block-diagonal structure (e.g. 75% zeros on a 32×32, full coverage when a dim is 1). Happy to add a structural test if you'd like.

## Verification

- Full suite: **938 passed**.
- Block-dropout produces block-diagonal sparse weights; both init strategies give finite MLP output; block-dropout-only generation is finite across seeds (single- and multi-table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)