### PR TITLE
Fix for Bug in processing rel-event user-attendance in regression task

### DIFF
--- a/rustler/src/pre.rs
+++ b/rustler/src/pre.rs
@@ -276,6 +276,8 @@ pub fn main(cli: Cli) {
                 || table_name == "user-attendance"
             {
                 df = df.drop("index").unwrap();
+            }            
+            if table_name == "user-repeat" || table_name == "user-ignore" {
                 df = cast_col_to_bool(df, "target").unwrap();
             }
         }


### PR DESCRIPTION
Hi Team, `user-attendance` is a regression task in `rel-event`. It was previously cast to a Boolean along with other correct classification task targets. I have made the changes to not typecast it. This might change the results in the leaderboard for the `rel-event user-attendance` regression task. 
Thank you!